### PR TITLE
Add Skip Checks (USE WITH CAUTION)

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -14,14 +14,18 @@ on:
         required: False
         type: string
         default: master
+      path:
+        required: False
+        type: string
+        default: .
+      skipDjangoCheck: # NOTE: Use with CAUTION!
+        required: False
+        type: boolean
+        default: false
       pythonVersion:
         required: False
         type: string
         default: 3.8-buster
-      path:
-        required: False
-        type: string
-        default: . # TODO: sub w backend
       # Linting config
       flake:
         required: False
@@ -35,6 +39,7 @@ jobs:
   django-check:
     name: Django Check
     runs-on: ubuntu-latest
+    if: ${{ !inputs.skipDjangoCheck }}
     steps:
       - uses: actions/checkout@v2
       - name: Cache
@@ -82,6 +87,10 @@ jobs:
   publish-backend:
     name: Publish backend
     runs-on: ubuntu-latest
+    needs: django-check
+    if: |
+      always() &&
+      (needs.django-check.result == 'success' || inputs.skipDjangoCheck == 'true')
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -104,4 +113,3 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache,type=registry,ref=pennlabs/${{ inputs.imageName }}:latest
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: pennlabs/${{ inputs.imageName }}:latest,pennlabs/${{ inputs.imageName }}:${{ github.sha }}
-    needs: django-check

--- a/.github/workflows/labs-application.yaml
+++ b/.github/workflows/labs-application.yaml
@@ -24,6 +24,10 @@ on:
         required: False
         type: string
         default: ${{ github.sha }}
+      skipChecks: # NOTE: Use with CAUTION!
+        required: False
+        type: boolean
+        default: false
     secrets:
       AWS_ACCOUNT_ID:
         required: true
@@ -39,6 +43,7 @@ jobs:
       projectName: ${{ inputs.projectName }}
       imageName: ${{ inputs.backendImageName }}
       defaultBranch: ${{ inputs.defaultBranch }}
+      skipDjangoCheck: ${{ inputs.skipChecks }}
       path: backend
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -50,6 +55,7 @@ jobs:
       projectName: ${{ inputs.projectName }}
       imageName: ${{ inputs.frontendImageName }}
       defaultBranch: ${{ inputs.defaultBranch }}
+      skipReactCheck: ${{ inputs.skipChecks }}
       path: frontend
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/react.yaml
+++ b/.github/workflows/react.yaml
@@ -14,14 +14,18 @@ on:
         required: False
         type: string
         default: master
-      nodeVersion:
-        required: False
-        type: string
-        default: 14
       path:
         required: False
         type: string
         default: .
+      skipReactCheck: # NOTE: Use with CAUTION!
+        required: False
+        type: boolean
+        default: false
+      nodeVersion:
+        required: False
+        type: string
+        default: 14
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -31,6 +35,7 @@ jobs:
   react-check:
     name: React Check
     runs-on: ubuntu-latest
+    if: ${{ !inputs.skipReactCheck }}
     steps:
       - uses: actions/checkout@v2
       - name: Cache
@@ -60,6 +65,10 @@ jobs:
   publish-frontend:
     name: Publish frontend
     runs-on: ubuntu-latest
+    needs: react-check
+    if: |
+      always() &&
+      (needs.react-check.result == 'success' || inputs.skipReactCheck == 'true')
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -82,4 +91,3 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache,type=registry,ref=pennlabs/${{ inputs.imageName }}:latest
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: pennlabs/${{ inputs.imageName }}:latest,pennlabs/${{ inputs.imageName }}:${{ github.sha }}
-    needs: react-check


### PR DESCRIPTION
**USE WITH CAUTION**: Allow skipping checks (React & Django). This is useful for quickly deploying projects or fixing broken products, but not recommended to be enabled.

This also makes our project compatible with legacy products such as Penn Basics, which currently fails the React checks imposed.