### PR TITLE
Add Ruff as linter option

### DIFF
--- a/django-check/action.yaml
+++ b/django-check/action.yaml
@@ -24,6 +24,10 @@ inputs:
         required: False
         description: "whether to use black for linting"
         default: "true"
+      ruff:
+        required: False
+        description: "whether to use ruff for linting"
+        default: "false"
       # Dependency manager config
       dependencyManager:
         required: False
@@ -73,5 +77,11 @@ runs:
           cd ${{ inputs.path }}
           ${{ inputs.dependencyManager }} run black --check . || ${{ inputs.dependencyManager }} run black --diff .
         if: ${{ inputs.black }}
+      - name: Lint (ruff)
+        shell: bash
+        run: |-
+          cd ${{ inputs.path }}
+          ${{ inputs.dependencyManager }} run ruff check . && (${{ inputs.dependencyManager }} run ruff format --check . || ${{ inputs.dependencyManager }} run ruff format --diff .
+        if: ${{ inputs.ruff }}
   container:
       image: python:${{ inputs.pythonVersion }}


### PR DESCRIPTION
Add [Ruff](https://docs.astral.sh/ruff/) as a linter option in the Django Check.

The following commands are essentially equivalent:
- `ruff check .` and `flake8 .`
- `ruff format --check .` and `black --check .`
- `ruff format --diff .` and `black --diff .`