### PR TITLE
Add back codecov

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -84,6 +84,16 @@ jobs:
           cd ${{ inputs.path }}
           ${{ inputs.dependencyManager }} run coverage run --concurrency=multiprocessing manage.py test --settings=${{ inputs.projectName }}.settings.ci --parallel
           ${{ inputs.dependencyManager }} run coverage combine
+          ${{ inputs.dependencyManager }} run coverage xml
+      - name: Upload Code Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ inputs.path }}
+          fail_ci_if_error: true
+          files: coverage.xml
+          name: codecov-umbrella
+          verbose: true
     container:
       image: python:${{ inputs.pythonVersion }}
     env:


### PR DESCRIPTION
Adds code coverage back to Django Check as per [this message](https://penn-labs.slack.com/archives/CM2MWEKUG/p1696286959098779). Currently expects apps to add `secrets: inherit` to their workflow in order to inherit the codecov token, might be a cleaner way to do this?