### PR TITLE
Add Bun, remove publish frontend step

### DIFF
--- a/.github/workflows/react.yaml
+++ b/.github/workflows/react.yaml
@@ -2,95 +2,55 @@ name: React Project Workflow
 on:
   workflow_call:
     inputs:
-      # Mandatory inputs
-      imageName:
-        required: TRUE
-        type: string
-      githubRef:
-        required: true
-        type: string
-      gitSha:
-        required: true
-        type: string
-      # Optional finetuning inputs
       path:
         required: False
         type: string
         default: .
-      dockerfile:
-        required: False
-        type: string
-        default: Dockerfile
-      skipReactCheck: # NOTE: Use with CAUTION!
-        required: False
-        type: boolean
-        default: false
       nodeVersion:
         required: False
         type: string
-        default: 14
-    secrets:
-      DOCKER_USERNAME:
-        required: true
-      DOCKER_PASSWORD:
-        required: true
+        default: "14"
+      dependencyManager:
+        required: False
+        type: string
+        description: "Dependency manager to use (e.g. yarn, bun)"
+        default: "yarn"
 jobs:
   react-check:
     name: React Check
     runs-on: ubuntu-latest
-    if: ${{ !inputs.skipReactCheck }}
     steps:
       - uses: actions/checkout@v2
-      - name: Cache
+      - name: Cache (yarn)
         uses: actions/cache@v2
         with:
           path: "**/node_modules"
           key: v0-${{ hashFiles('${{ inputs.path }}/yarn.lock') }}
+        if: ${{ inputs.dependencyManager == 'yarn' }}
+      - name: Cache (bun)
+        uses: actions/cache@v2
+        with:
+          path: |-
+            **/node_modules
+            **/.bun
+          key: v0-${{ hashFiles('${{ inputs.path }}/bun.lockb') }}
+        if: ${{ inputs.dependencyManager == 'bun' }}
       - name: Install Dependencies
         run: |-
           cd ${{ inputs.path }}
-          yarn install --frozen-lockfile
+          ${{ inputs.dependencyManager }} install --frozen-lockfile
       - name: Lint
         run: |-
           cd ${{ inputs.path }}
-          yarn lint
+          ${{ inputs.dependencyManager }} lint
       - name: Test
         run: |-
           cd ${{ inputs.path }}
-          yarn test
+          ${{ inputs.dependencyManager }} run test
       - name: Upload Code Coverage
         run: |-
           ROOT=$(pwd)
           cd ${{ inputs.path }}
-          yarn run codecov -p $ROOT -F frtype=local,src=/tmp/.buildx-cacheontend
+          ${{ inputs.dependencyManager }} run codecov -p $ROOT -F frtype=local,src=/tmp/.buildx-cacheontend
     container:
       image: node:${{ inputs.nodeVersion }}
-  publish-frontend:
-    name: Publish frontend
-    runs-on: ubuntu-latest
-    needs: react-check
-    if: |
-      always() &&
-      (needs.react-check.result == 'success' || needs.react-check.result == 'skipped')
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-publish-frontend
-      - uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build/Publish
-        uses: docker/build-push-action@v2
-        with:
-          context: ${{ inputs.path }}
-          file: ${{ inputs.path }}/${{ inputs.dockerfile }}
-          push: ${{ inputs.githubRef == 'master' }}
-          cache-from: type=local,src=/tmp/.buildx-cache,type=registry,ref=pennlabs/${{ inputs.imageName }}:latest
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          tags: pennlabs/${{ inputs.imageName }}:latest,pennlabs/${{ inputs.imageName }}:${{ inputs.gitSha }}


### PR DESCRIPTION
Add [Bun](https://bun.sh/) as a frontend dependency manager option and remove the publish frontend step from the frontend check (Clubs, OHQ, and Courses appear to be using pinned versions that don't contain this step; this also makes the frontend check more consistent with the backend check, which doesn't have the publish step either).