### PR TITLE
Migrate frontend from node-specific Codecov uploader library to Github Action

### DIFF
--- a/.github/workflows/react.yaml
+++ b/.github/workflows/react.yaml
@@ -59,10 +59,13 @@ jobs:
           cd ${{ inputs.path }}
           yarn test
       - name: Upload Code Coverage
-        run: |-
-          ROOT=$(pwd)
-          cd ${{ inputs.path }}
-          yarn run codecov -p $ROOT -F frtype=local,src=/tmp/.buildx-cacheontend
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ inputs.path }}
+          fail_ci_if_error: true
+          name: codecov-umbrella
+          verbose: true
     container:
       image: node:${{ inputs.nodeVersion }}
   publish-frontend:


### PR DESCRIPTION
The [Codecov NodeJS uploader](https://www.npmjs.com/package/codecov) has been deprecated since 2022: this PR changes the React workflow to use the new uploader through the official Github Action wrapper.

This has been completed a while ago for backend through the following PRs (in net):

- #12
- #18 