### PR TITLE
Make codecov optional in frontend workflow

### DIFF
--- a/.github/workflows/react.yaml
+++ b/.github/workflows/react.yaml
@@ -29,6 +29,10 @@ on:
         required: False
         type: string
         default: 14
+      skipCodecov:
+        required: False
+        type: boolean
+        default: false
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -60,6 +64,7 @@ jobs:
           yarn test
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
+        if: ${{ !inputs.skipCodecov }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ${{ inputs.path }}


### PR DESCRIPTION
Codecov has been included in the Penn Clubs frontend actions workflow for some time, but we do not run any frontend tests (this step has also been failing silently for a while – see [here](https://github.com/pennlabs/penn-clubs/actions/runs/10427586659/job/28882492409#step:8:1)). To prevent this, we would like to make the Codecov check optional