### PR TITLE
Bump actions, fix typos

### DIFF
--- a/django-check/action.yaml
+++ b/django-check/action.yaml
@@ -2,86 +2,86 @@ name: "Django Check Composite"
 description: "Checks django as a composite action"
 
 inputs:
-      # Mandatory inputs
-      projectName:
-        required: true
-        description: "Name of project"
-      # Optional finetuning inputs
-      path:
-        required: False
-        description: "path"
-        default: .
-      pythonVersion:
-        required: False
-        description: "Python version to use"
-        default: 3.8-buster
-      # Linting config
-      flake:
-        required: False
-        description: "whether to use flake for linting"
-        default: "true"
-      black:
-        required: False
-        description: "whether to use black for linting"
-        default: "true"
-      ruff:
-        required: False
-        description: "whether to use ruff for linting"
-        default: "false"
-      # Dependency manager config
-      dependencyManager:
-        required: False
-        description: "Dependency manager to use (e.g., pipenv, poetry)"
-        default: 'pipenv'
+  # Mandatory inputs
+  projectName:
+    required: true
+    description: "Name of project"
+  # Optional finetuning inputs
+  path:
+    required: false
+    description: "path"
+    default: .
+  pythonVersion:
+    required: false
+    description: "Python version to use"
+    default: 3.8-buster
+  # Linting config
+  flake:
+    required: false
+    description: "whether to use flake for linting"
+    default: "true"
+  black:
+    required: false
+    description: "whether to use black for linting"
+    default: "true"
+  ruff:
+    required: false
+    description: "whether to use ruff for linting"
+    default: "false"
+  # Dependency manager config
+  dependencyManager:
+    required: false
+    description: "Dependency manager to use (e.g., pipenv, poetry)"
+    default: "pipenv"
 
 runs:
   using: "composite"
   steps:
-      - uses: actions/checkout@v2
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.local/share/virtualenvs
-          key: v0-${{ hashFiles('${{ inputs.path }}/Pipfile.lock') }}
-      - name: Install Dependencies (pipenv)
-        shell: bash
-        continue-on-error: true
-        run: |-
-          cd ${{ inputs.path }}
-          pip install pipenv
-          pipenv install --deploy --dev
-        if: ${{ inputs.dependencyManager == 'pipenv' }}
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        if: ${{ inputs.dependencyManager == 'poetry' }}
-      - name: Install Dependencies (poetry)
-        shell: bash
-        continue-on-error: true
-        run: poetry install --no-root
-        if: ${{ inputs.dependencyManager == 'poetry' }}
-      - name: Test (run in parallel)
-        shell: bash
-        run: |-
-          cd ${{ inputs.path }}
-          ${{ inputs.dependencyManager }} run coverage run --concurrency=multiprocessing manage.py test --settings=${{ inputs.projectName }}.settings.ci --parallel
-          ${{ inputs.dependencyManager }} run coverage combine
-      - name: Lint (flake8)
-        shell: bash
-        run: |-
-          cd ${{ inputs.path }}
-          ${{ inputs.dependencyManager }} run flake8 .
-        if: ${{ inputs.flake }}
-      - name: Lint (black)
-        shell: bash
-        run: |-
-          cd ${{ inputs.path }}
-          ${{ inputs.dependencyManager }} run black --check . || ${{ inputs.dependencyManager }} run black --diff .
-        if: ${{ inputs.black }}
-      - name: Lint (ruff)
-        shell: bash
-        run: |-
-          cd ${{ inputs.path }}
-          ${{ inputs.dependencyManager }} run ruff check . && ${{ inputs.dependencyManager }} run ruff format --check . || ${{ inputs.dependencyManager }} run ruff format --diff .
-        if: ${{ inputs.ruff }}
+    - uses: actions/checkout@v4
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/virtualenvs
+        key: v0-${{ hashFiles('${{ inputs.path }}/Pipfile.lock') }}
+    - name: Install Dependencies (pipenv)
+      shell: bash
+      continue-on-error: true
+      run: |-
+        cd ${{ inputs.path }}
+        pip install pipenv
+        pipenv install --deploy --dev
+      if: ${{ inputs.dependencyManager == 'pipenv' }}
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.3
+      if: ${{ inputs.dependencyManager == 'poetry' }}
+    - name: Install Dependencies (poetry)
+      shell: bash
+      continue-on-error: true
+      run: poetry install --no-root
+      if: ${{ inputs.dependencyManager == 'poetry' }}
+    - name: Test (run in parallel)
+      shell: bash
+      run: |-
+        cd ${{ inputs.path }}
+        ${{ inputs.dependencyManager }} run coverage run --concurrency=multiprocessing manage.py test --settings=${{ inputs.projectName }}.settings.ci --parallel
+        ${{ inputs.dependencyManager }} run coverage combine
+    - name: Lint (flake8)
+      shell: bash
+      run: |-
+        cd ${{ inputs.path }}
+        ${{ inputs.dependencyManager }} run flake8 .
+      if: ${{ inputs.flake == 'true' }}
+    - name: Lint (black)
+      shell: bash
+      run: |-
+        cd ${{ inputs.path }}
+        ${{ inputs.dependencyManager }} run black --check . || ${{ inputs.dependencyManager }} run black --diff .
+      if: ${{ inputs.black == 'true' }}
+    - name: Lint (ruff)
+      shell: bash
+      run: |-
+        cd ${{ inputs.path }}
+        ${{ inputs.dependencyManager }} run ruff check . && ${{ inputs.dependencyManager }} run ruff format --check . || ${{ inputs.dependencyManager }} run ruff format --diff .
+      if: ${{ inputs.ruff == 'true' }}
   container:
-      image: python:${{ inputs.pythonVersion }}
+    image: python:${{ inputs.pythonVersion }}

--- a/django-check/action.yaml
+++ b/django-check/action.yaml
@@ -70,18 +70,18 @@ runs:
       run: |-
         cd ${{ inputs.path }}
         ${{ inputs.dependencyManager }} run flake8 .
-      if: ${{ inputs.flake == 'true' }}
+      if: ${{ inputs.flake }}
     - name: Lint (black)
       shell: bash
       run: |-
         cd ${{ inputs.path }}
         ${{ inputs.dependencyManager }} run black --check . || ${{ inputs.dependencyManager }} run black --diff .
-      if: ${{ inputs.black == 'true' }}
+      if: ${{ inputs.black }}
     - name: Lint (ruff)
       shell: bash
       run: |-
         cd ${{ inputs.path }}
         ${{ inputs.dependencyManager }} run ruff check . && ${{ inputs.dependencyManager }} run ruff format --check . || ${{ inputs.dependencyManager }} run ruff format --diff .
-      if: ${{ inputs.ruff == 'true' }}
+      if: ${{ inputs.ruff }}
   container:
     image: python:${{ inputs.pythonVersion }}

--- a/react-check/action.yaml
+++ b/react-check/action.yaml
@@ -3,14 +3,13 @@ description: "Checks and runs tests for react project"
   
 inputs:
   # Path input is only required if building a project with front and backends
-
   path:
-    required: False
+    required: false
     description: "Path to project root"
     default: .
 
   nodeVersion:
-    required: False
+    required: false
     description: "Node version to use"
     default: 14.17.0
 
@@ -18,14 +17,14 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Node ${{ inputs.nodeVersion }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.nodeVersion }}
         cache: "yarn"
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: "**/node_modules"
         key: v0-${{ hashFiles('${{ inputs.path }}/yarn.lock') }}
@@ -52,6 +51,6 @@ runs:
       run: |-
         ROOT=$(pwd)
         cd ${{ inputs.path }}
-        yarn run codecov -p $ROOT -F frtype=local,src=/tmp/.buildx-cacheontend
+        yarn run codecov -p $ROOT -F frtype=local,src=/tmp/.buildx-cache
 # container:
 #   image: node:${{ inputs.nodeVersion }}


### PR DESCRIPTION
Github actions deprecated their v2 actions which is causing all our stuff to fail, I bumped the actions and fixed a few typos I think. I'm kinda bad at github actions though so could someone review
- Bump actions/checkout, actions/cache, actions/setup-node from v2 to v4
- Bump snok/install-poetry from v1 to v3
- I think this was a typo? "frtype=local,src=/tmp/.buildx-cacheontend" -> "frtype=local,src=/tmp/.buildx-cache"