### PR TITLE
Bump actions/cache to v4 django

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: buildx-publish-landing


### PR DESCRIPTION
- Bumped the last remaining actions/cache reference to v4; now deprecated