### PR TITLE
Update deployment skip condition

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ inputs.githubRef }} == 'refs/heads/master'
+    if: ${{ inputs.githubRef == 'refs/heads/master' }} 
     steps:
       - uses: actions/checkout@v2
       - id: synth


### PR DESCRIPTION
Our deployment script conditional was incorrect.

The script was running on EVERY commit on every branch. This should not be the case, for deployment script should only run on main/master branch. This check was in place, but had incorrect syntax. This has been corrected.