### PR TITLE
Rename Image To Correct Tag

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ inputs.githubRef }} == 'refs/heads/master'
+    if: ${{ inputs.githubRef == 'refs/heads/master' }} 
     steps:
       - uses: actions/checkout@v2
       - id: synth

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -59,4 +59,4 @@ jobs:
           push: ${{ inputs.githubRef == 'refs/heads/master' }}
           cache-from: ${{ inputs.cache && 'type=local,src=/tmp/.buildx-cache,type=registry,ref=pennlabs/${{ inputs.imageName }}:latest' }}
           cache-to: ${{ inputs.cache && 'type=local,dest=/tmp/.buildx-cache' }}
-          tags: ${{ inputs.imageName }}:latest,${{ inputs.imageName }}:${{ inputs.gitSha }}
+          tags: pennlabs/${{ inputs.imageName }}:latest,pennlabs/${{ inputs.imageName }}:${{ inputs.gitSha }}


### PR DESCRIPTION
The current tagged version did not include the correct org. This fixes the issue where docker publish could not find the image associated with the credentials given. 